### PR TITLE
Added display_name length in discover for future-proofing

### DIFF
--- a/lib/inc/protocol/scrutiny_codec_v1_0.h
+++ b/lib/inc/protocol/scrutiny_codec_v1_0.h
@@ -132,6 +132,7 @@ namespace scrutiny
 			{
 				struct Discover
 				{
+					uint8_t display_name_length;
 					const char* display_name;
 				};
 				struct Heartbeat

--- a/lib/test/commands/test_comm_control.cpp
+++ b/lib/test/commands/test_comm_control.cpp
@@ -22,7 +22,7 @@ protected:
 	virtual void SetUp()
 	{
 		config.max_bitrate = 0x12345678;
-		config.set_display_name("hello");
+		config.set_display_name("helloworld");
 		scrutiny_handler.init(&config);
 	}
 };
@@ -35,12 +35,13 @@ TEST_F(TestCommControl, TestDiscover)
 	ASSERT_EQ(sizeof(scrutiny::protocol::CommControl::DISCOVER_MAGIC), 4u);
 	uint8_t request_data[8 + 4] = { 2,1,0,4};
 	std::memcpy(&request_data[4], scrutiny::protocol::CommControl::DISCOVER_MAGIC, sizeof(scrutiny::protocol::CommControl::DISCOVER_MAGIC));
-
+	std::string display_name = std::string("helloworld");
 
 	uint8_t tx_buffer[64];
-	uint8_t expected_response[9 + 32+5] = { 0x82,1,0,0,32+5};   // Version 1.0
+	uint8_t expected_response[9 + 32+1+10] = { 0x82,1,0,0,32+1+10};   // Version 1.0
 	std::memcpy(&expected_response[5], scrutiny::software_id, sizeof(scrutiny::software_id));
-	std::memcpy(&expected_response[5+sizeof(scrutiny::software_id)], "hello", 5);
+	expected_response[5 + sizeof(scrutiny::software_id)] = display_name.length();
+	std::memcpy(&expected_response[5+sizeof(scrutiny::software_id)+1], display_name.c_str(), display_name.length());
 
 	add_crc(request_data, sizeof(request_data) - 4);
 	add_crc(expected_response, sizeof(expected_response) - 4);

--- a/python/scrutiny/server/device/emulated_device.py
+++ b/python/scrutiny/server/device/emulated_device.py
@@ -31,7 +31,7 @@ class EmulatedDevice:
             raise ValueError('EmulatedDevice expects a DummyLink object')
         self.logger = logging.getLogger(self.__class__.__name__)
         self.link = link    # Preopened link.
-        self.firmware_id = bytes([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        self.firmware_id = bytes(range(32))
         self.request_history = []
         self.protocol = Protocol(1, 0)
 

--- a/python/test/server/protocol/test_protocol_v1_0.py
+++ b/python/test/server/protocol/test_protocol_v1_0.py
@@ -293,6 +293,7 @@ class TestProtocolV1_0(unittest.TestCase):
 
 # ============= CommControl ===============
 
+
     def test_req_comm_discover(self):
         magic = bytes([0x7e, 0x18, 0xfc, 0x68])
         request_bytes = bytes([2, 1, 0, 4]) + magic
@@ -431,7 +432,6 @@ class TestProtocolV1_0(unittest.TestCase):
 
 # ============= UserCommand ===============
 
-
     def test_req_user_command(self):
         req = self.proto.user_command(10, bytes([1, 2, 3]))
         self.assert_req_response_bytes(req, [4, 10, 0, 3, 1, 2, 3])
@@ -445,7 +445,6 @@ class TestProtocolV1_0(unittest.TestCase):
 # ============================
 
 # =============  GetInfo ==============
-
 
     def test_response_get_protocol_version(self):
         response = self.proto.respond_protocol_version(major=2, minor=3)
@@ -490,7 +489,6 @@ class TestProtocolV1_0(unittest.TestCase):
 
 
 # ============= MemoryControl ===============
-
 
     def test_response_read_single_memory_block_8bits(self):
         self.proto.set_address_size_bits(8)
@@ -691,7 +689,8 @@ class TestProtocolV1_0(unittest.TestCase):
     def test_response_comm_discover(self):
         firmwareid = bytes(range(32))
         display_name = 'hello'
-        response_bytes = bytes([0x82, 1, 0, 0, len(firmwareid) + len(display_name.encode('utf8'))]) + firmwareid + display_name.encode('utf8')
+        payload_length = len(firmwareid) + 1 + len(display_name.encode('utf8'))
+        response_bytes = bytes([0x82, 1, 0, 0, payload_length]) + firmwareid + struct.pack('B', len(display_name)) + display_name.encode('utf8')
         response = self.proto.respond_comm_discover(firmwareid, display_name)
         self.assert_req_response_bytes(response, response_bytes)
         data = self.proto.parse_response(response)


### PR DESCRIPTION
Added a string length before the display_name in Discover request so that we can add additional info at the end later on.